### PR TITLE
Load MathJax from cloudflare CDN.

### DIFF
--- a/app/edit.py
+++ b/app/edit.py
@@ -139,7 +139,7 @@ class EditHandler(users.AuthenticatedHandler):
         o.write('<span id="authetication">%s</span>' % auth);
         o.write("""
 <script type="text/javascript"
-  src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 <script src="/js/verify.js" type="text/javascript"></script>
 <script src="/js/sandbox.js" type="text/javascript"></script>

--- a/app/showthm.py
+++ b/app/showthm.py
@@ -87,7 +87,7 @@ class ProofFormatter:
 '''</div>
 <script src="/js/verify.js" type="text/javascript"></script>
 <script type="text/javascript"
-  src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 <script src="/js/showthm.js" type="text/javascript"></script>
 <script src="/js/proofstep.js" type="text/javascript"></script>

--- a/app/wiki.py
+++ b/app/wiki.py
@@ -48,7 +48,7 @@ class Handler(users.AuthenticatedHandler):
             o.write('<script src="/js/prover/setUtil.js" type="text/javascript"></script>')
             o.write('<script src="/js/prover/tupleUtil.js" type="text/javascript"></script>')
             o.write('<script type="text/javascript"')
-            o.write('  src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">')
+            o.write('  src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">')
             o.write('</script>')
             o.write('<div id="text-body">')
             # o.write("Ghilbert wiki: " + arg)


### PR DESCRIPTION
See https://www.mathjax.org/cdn-shutting-down/ .