### PR TITLE
Allow duplicate interface params.

### DIFF
--- a/verify.py
+++ b/verify.py
@@ -18,7 +18,6 @@ import sys
 import os.path
 import array
 
-
 # for debug printing
 def sexp_to_string(sexp):
     buf = array.array('c')
@@ -438,16 +437,12 @@ class VerifyCtx:
 
             if ifname in self.interfaces:
                 raise VerifyError("An interface named %s already exists." % ifname)
-            # Check that the parameter interfaces are all distinct and all
-            # correspond to existing interfaces.
-            inverse = {}
+            # Check that the parameter interfaces are all correspond to existing
+            # interfaces.
             params = []
             for pn in paramnames:
                 if (type(pn) != type('string')):
                     raise VerifyError("%s parameter must be an interface name." % cmd)
-                if pn in inverse:
-                    raise VerifyError("Interface %s passed more than once to import context." % pn)
-                inverse[pn] = 0
                 try:
                     params.append(self.interfaces[pn])
                 except KeyError:
@@ -962,6 +957,12 @@ class InterfaceCtx:
         self.mykinds = {}
         self.error_handler = None
 
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return self.name
+
     def get_kind(self, rawkind):
         try:
             return self.kinds[rawkind]
@@ -1042,7 +1043,10 @@ class InterfaceCtx:
         if subparams != p.params:
             raise VerifyError('Context ' + self.name + \
                    ' changes parameters to parameter interface ' + \
-                   ifname + ' (' + p.name + ')')
+                              ifname + ' (' + p.name + ').\n' + \
+                              'was: ' + repr(p.params) + '\n' +\
+                              'now: ' + repr(subparams)
+            )
 
         self.used_params[ifname] = p
 


### PR DESCRIPTION
This change seems to be required in order to define an interface
generally as accepting two different types, but then allow it to be
used in a specific instance where the types are the same.

(Also: improve the error message on param mismatch, which is very
useful in debugging a typo in a complex nest of param layers.)

--

@raphlinus, please let me know whether you think this is sound or not. I don't know the reason why duplicate params were forbidden in the first place. This change was needed in order to verify my attemp at codifying typed SK combinators:
  https://github.com/abliss/ghilbert-app/commit/ccc205d9307f8989a4b3fd80e04f16a9c1490b3e
I tried to do so as you suggested on the mailing list, and was unable to do it without this modification to the verifier. (But maybe I misunderstood what you meant, in which case, please let me know.)